### PR TITLE
Several fixes to get extension working with v12

### DIFF
--- a/Classes/Helper/MoUtilities.php
+++ b/Classes/Helper/MoUtilities.php
@@ -14,10 +14,10 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
 
-const SEP = DIRECTORY_SEPARATOR;
-
 class MoUtilities
 {
+    const SEP = DIRECTORY_SEPARATOR;
+
     public static function getHelperDir()
     {
         global $sep;
@@ -106,9 +106,9 @@ class MoUtilities
     public static function getImageUrl($imgFileName)
     {
         error_log("getImageUrl");
-        $imageDir = self::getResourceDir() . SEP . 'images' . SEP;
+        $imageDir = self::getResourceDir() . self::SEP . 'images' . self::SEP;
         error_log("resDir : " . $imageDir);
-        $iconDir = self::getExtensionRelativePath() . SEP . 'Resources' . SEP . 'Public' . SEP . 'Icons' . SEP;
+        $iconDir = self::getExtensionRelativePath() . self::SEP . 'Resources' . self::SEP . 'Public' . self::SEP . 'Icons' . self::SEP;
         error_log("iconDir : " . print_r($iconDir, true));
         return $iconDir . $imgFileName;
     }

--- a/Classes/Helper/Utilities.php
+++ b/Classes/Helper/Utilities.php
@@ -14,11 +14,9 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\PathUtility;
 
-const SEP = DIRECTORY_SEPARATOR;
-
-
 class Utilities
 {
+    protected const SEP = DIRECTORY_SEPARATOR;
 
     /**
      * This function checks if a value is set or
@@ -72,8 +70,8 @@ class Utilities
      */
     public static function getImageUrl($imgFileName)
     {
-        $imageDir = self::getResourceDir() . SEP . 'images' . SEP;
-        $iconDir = self::getExtensionRelativePath() . SEP . 'Resources' . SEP . 'Public' . SEP . 'Icons' . SEP;
+        $imageDir = self::getResourceDir() . self::SEP . 'images' . self::SEP;
+        $iconDir = self::getExtensionRelativePath() . self::SEP . 'Resources' . self::SEP . 'Public' . self::SEP . 'Icons' . self::SEP;
         return $iconDir . $imgFileName;
     }
 

--- a/Configuration/TCA/tx_oauth_domain_model_beoidc.php
+++ b/Configuration/TCA/tx_oauth_domain_model_beoidc.php
@@ -1,7 +1,7 @@
 <?php
 return [
     'ctrl' => [
-        'title' => 'LLL:EXT:EXT:oauth/Resources/Private/Language/locallang_db.xlf:tx_oauth_domain_model_beoidc',
+        'title' => 'LLL:EXT:oauth/Resources/Private/Language/locallang_db.xlf:tx_oauth_domain_model_beoidc',
         'label' => 'uid',
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
@@ -17,7 +17,7 @@ return [
             'endtime' => 'endtime',
         ],
         'searchFields' => '',
-        'iconfile' => 'EXT:EXT:oauth/Resources/Public/Icons/tx_oauth_domain_model_beoidc.gif'
+        'iconfile' => 'EXT:oauth/Resources/Public/Icons/tx_oauth_domain_model_beoidc.gif'
     ],
     'interface' => [
         'showRecordFieldList' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, ',

--- a/Configuration/TCA/tx_oauth_domain_model_feoidc.php
+++ b/Configuration/TCA/tx_oauth_domain_model_feoidc.php
@@ -1,7 +1,7 @@
 <?php
 return [
     'ctrl' => [
-        'title' => 'LLL:EXT:EXT:oauth/Resources/Private/Language/locallang_db.xlf:tx_oauth_domain_model_feoidc',
+        'title' => 'LLL:EXT:oauth/Resources/Private/Language/locallang_db.xlf:tx_oauth_domain_model_feoidc',
         'label' => 'uid',
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
@@ -17,7 +17,7 @@ return [
             'endtime' => 'endtime',
         ],
         'searchFields' => '',
-        'iconfile' => 'EXT:EXT:oauth/Resources/Public/Icons/tx_oauth_domain_model_feoidc.gif'
+        'iconfile' => 'EXT:oauth/Resources/Public/Icons/tx_oauth_domain_model_feoidc.gif'
     ],
     'interface' => [
         'showRecordFieldList' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, ',

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -75,7 +75,7 @@ call_user_func(
                         description = LLL:EXT:oauth/Resources/Private/Language/locallang_db.xlf:tx_oauth_feoidc.description
                         tt_content_defValues {
                             CType = list
-                            list_type = Feoidc
+                            list_type = oauth_feoidc
                         }
                     }
                     Responsekey {
@@ -84,7 +84,7 @@ call_user_func(
                         description = LLL:EXT:oauth/Resources/Private/Language/locallang_db.xlf:tx_oauth_response.description
                         tt_content_defValues {
                             CType = list
-                            list_type = Response
+                            list_type = oauth_response
                         }
                     }
                 }


### PR DESCRIPTION
Fix conflict with constant SEP 

Resolves: #8

-----

Replace EXT:EXT: in TCA files
    
Resolves: #7

------

Use correct list_type in newContentElement
    
Resolves: #16

-----

**Note to maintainer**: I provide patches in hope that it will be helpful for you and the community. Please do not feel obligated to be polite. If it saves you time, I would be happy if you merge, but if it is faster for you to make changes myself - please feel free to close my PR.

Also, I provide changes as is. I tested them on my system with TYPO3 v12, but I cannot fully guarantee that it works 100% in all scenarios. I trust you will test as you deem necessary before merging or providing a release.

Also, I categorically refuse to touch anything below TYPO3 v12, so I won't be testing this in older versions. I assume most of what I provide should be ok with older version, but I am not sure in the change for [TSconfig](https://github.com/miniOrangeDev/typo3-oidc-free/pull/14/commits/68f8c8349e48618775a0e1eb9f5960511e370898).
I notice, you still support versions as low as v8. It might be prudent to drop support for older versions before merging this. You can branch out if you still want to support older versions and backport changes. 

Also, having no tests at all, not even phpstan always makes me uneasy, that would be very much appreciated if some tests and checks were added.

Initially, this extension did not work at all on my system. 


