### PR TITLE
Update BeoidcController.php

### DIFF
--- a/Classes/Controller/BeoidcController.php
+++ b/Classes/Controller/BeoidcController.php
@@ -211,7 +211,7 @@ class BeoidcController extends ActionController
             return 0;
         }
     }
-
+    private string $oidc_object;
     /**
      * @param $postArray
      */


### PR DESCRIPTION
Fixed deprecated dynamic property creation in BeoidcController for PHP 8.2 compatibility.  Added the $oidc_object property explicitly to the class to avoid runtime deprecation warnings.